### PR TITLE
Add no-releases deploy recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ When _not_ using `public` as the web directory, please set it respectively:
 
 - `dep deploy [host]`
 
+### Deploy without releases
+
+If your target host should not use Deployer's `releases/` structure, import the no-releases recipe in your `deploy.php`:
+
+```php
+import(__DIR__.'/vendor/nutshell-framework/deployer-recipes/recipe/deploy/no_releases.php');
+```
+
+This deploys directly into `deploy_path`. Keep in mind that release-based rollbacks are not available in this mode.
+
 ### Custom _.htaccess_ file per host
 
 Create a _.htaccess_ file in your project, e.g., `.htaccess_prod`, then configure it for the host:

--- a/recipe/deploy/no_releases.php
+++ b/recipe/deploy/no_releases.php
@@ -52,3 +52,9 @@ task('deploy:cleanup', static function () {
 task('rollback', static function () {
     // Rollback through previous releases is not possible without releases.
 });
+
+task('contao:manager:lock', static function () {
+    cd('{{release_or_current_path}}');
+    run('mkdir -p contao-manager');
+    run('echo "99" > contao-manager/login.lock');
+});

--- a/recipe/deploy/no_releases.php
+++ b/recipe/deploy/no_releases.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+use function Deployer\Support\str_contains;
+
+desc('Preparing host for deploy without releases');
+task('deploy:prepare', function () {
+    // Check if shell is POSIX-compliant
+    $result = run('echo $0');
+
+    if (!str_contains($result, 'bash') && !str_contains($result, 'sh')) {
+        throw new \RuntimeException('Shell on your server is not POSIX-compliant. Please change to sh, bash or similar.');
+    }
+
+    run('if [ ! -d {{deploy_path}} ]; then mkdir -p {{deploy_path}}; fi');
+
+    // Create metadata .dep dir.
+    run('cd {{deploy_path}} && if [ ! -d .dep ]; then mkdir .dep; fi');
+})->hidden();
+
+set('release_path', static function () {
+    return get('deploy_path');
+});
+
+task('deploy:release', static function () {
+    // No release folder is created.
+})->hidden();
+
+task('deploy:shared', static function () {
+    // Shared links are not required without releases.
+})->hidden();
+
+task('deploy:symlink', static function () {
+    // Symlink switching is not required without releases.
+})->hidden();
+
+task('deploy:cleanup', static function () {
+    // Cleanup of old releases is not required without releases.
+})->hidden();
+
+task('rollback', static function () {
+    // Rollback through previous releases is not possible without releases.
+});

--- a/recipe/deploy/no_releases.php
+++ b/recipe/deploy/no_releases.php
@@ -7,7 +7,7 @@ namespace Deployer;
 use function Deployer\Support\str_contains;
 
 desc('Preparing host for deploy without releases');
-task('deploy:prepare', function () {
+task('deploy:setup', function () {
     // Check if shell is POSIX-compliant
     $result = run('echo $0');
 

--- a/recipe/deploy/no_releases.php
+++ b/recipe/deploy/no_releases.php
@@ -25,6 +25,14 @@ set('release_path', static function () {
     return get('deploy_path');
 });
 
+set('current_path', static function () {
+    return get('deploy_path');
+});
+
+set('release_or_current_path', static function () {
+    return get('deploy_path');
+});
+
 task('deploy:release', static function () {
     // No release folder is created.
 })->hidden();


### PR DESCRIPTION
## Zusammenfassung
- Fügt ein Deploy-Recipe ohne Release-Handling hinzu.
- Bestehendes Verhalten der bisherigen Recipes bleibt unverändert.

## Warum
Einige Deployments arbeiten ohne Release-Verzeichnisse und brauchen einen einfacheren Ablauf.

## Hinweise
- Kein Breaking Change beabsichtigt.
- Standard-Recipe bleibt unverändert.